### PR TITLE
Set severity to INFO if making calendar private

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -150,19 +150,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:65d052ec13197460586ee385aa2d6bba0e7378d2d2c7f3e93c044c43ae1ca782",
-                "sha256:94218aba2feb5b404b665b8d76c172dc654f79b4c5fa0e9e92459c098da87bf4"
+                "sha256:9d52a1605657aeb5b19b09cfc01d9a92f88a616a5daf5479a59656d6341ea6b3",
+                "sha256:ff3d0116e0ca6c096547652390025780eace3a28f6c04c9ffbf38448f1e5a87b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.63"
+            "version": "==1.28.65"
         },
         "botocore": {
             "hashes": [
-                "sha256:6e582c811ea74f25bdb490ac372b2645de4a60286b42ddd8c69f3b6df82b6b12",
-                "sha256:cb9db5db5af865b1fc2e1405b967db5d78dd0f4d84e5dc1974e082733c1034b7"
+                "sha256:90716c6f1af97e5c2f516e9a3379767ebdddcc6cbed79b026fa5038ce4e5e43e",
+                "sha256:f74e3da98dfcec17bc63ef58f82c643bf5bd7ec6cc11a26ede21cc4cd064917f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.63"
+            "version": "==1.31.65"
         },
         "certifi": {
             "hashes": [
@@ -1068,11 +1068,11 @@
         },
         "sqlfluff": {
             "hashes": [
-                "sha256:185e1122056bee3e2098346f0123dd80ac822727cabb418e82fa56ee978db0db",
-                "sha256:a1f235f07279429e24570e76c86799616ff3e9a73134d83c31cd290f225610be"
+                "sha256:9d79ffdc3bb7790815db8b71dbf40fdb277774a12f6c14e9420f666446801ffc",
+                "sha256:cbff620077e38c68af3aa0d63d9f87d3745156ad3dcea71245f8caa0b09a0b82"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.3.3"
+            "version": "==2.3.4"
         },
         "tblib": {
             "hashes": [
@@ -1116,11 +1116,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21",
-                "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.17"
+            "version": "==1.26.18"
         },
         "yarl": {
             "hashes": [
@@ -1242,19 +1243,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:65d052ec13197460586ee385aa2d6bba0e7378d2d2c7f3e93c044c43ae1ca782",
-                "sha256:94218aba2feb5b404b665b8d76c172dc654f79b4c5fa0e9e92459c098da87bf4"
+                "sha256:9d52a1605657aeb5b19b09cfc01d9a92f88a616a5daf5479a59656d6341ea6b3",
+                "sha256:ff3d0116e0ca6c096547652390025780eace3a28f6c04c9ffbf38448f1e5a87b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.63"
+            "version": "==1.28.65"
         },
         "botocore": {
             "hashes": [
-                "sha256:6e582c811ea74f25bdb490ac372b2645de4a60286b42ddd8c69f3b6df82b6b12",
-                "sha256:cb9db5db5af865b1fc2e1405b967db5d78dd0f4d84e5dc1974e082733c1034b7"
+                "sha256:90716c6f1af97e5c2f516e9a3379767ebdddcc6cbed79b026fa5038ce4e5e43e",
+                "sha256:f74e3da98dfcec17bc63ef58f82c643bf5bd7ec6cc11a26ede21cc4cd064917f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.63"
+            "version": "==1.31.65"
         },
         "certifi": {
             "hashes": [
@@ -1483,11 +1484,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33",
-                "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"
+                "sha256:4d683e8957c8998b58ddb937e3e6cd167215a180e1ffd4da769ab81c620a89fe",
+                "sha256:9e98b672ffcb081c2c8d5aa630d4251544fb040fb158863054242f24a2a2ba30"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.37"
+            "version": "==3.1.38"
         },
         "idna": {
             "hashes": [
@@ -1916,11 +1917,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21",
-                "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.17"
+            "version": "==1.26.18"
         },
         "werkzeug": {
             "hashes": [

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -6,7 +6,7 @@ PackDefinition:
     - Okta.AdminRoleAssigned
     - Okta.APIKeyCreated
     - Okta.APIKeyRevoked
-    - Okta.GeographicallyImprobableAccess
+    # - Okta.GeographicallyImprobableAccess DEPRECATED
     - Okta.Support.Access
     - Okta.Global.MFA.Disabled
     - Okta.ThreatInsight.Security.Threat.Detected

--- a/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.py
@@ -1,7 +1,11 @@
-from panther_base_helpers import aws_guardduty_context
+from panther_base_helpers import aws_guardduty_context, deep_get
 
 
 def rule(event):
+    if deep_get(event, "service", "additionalInfo", "sample"):
+        # in case of sample data
+        # https://docs.aws.amazon.com/guardduty/latest/ug/sample_findings.html
+        return False
     return 7.0 <= float(event.get("severity", 0)) <= 8.9
 
 

--- a/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
@@ -66,3 +66,48 @@ Tests:
         "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
         "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
       }
+  -
+    Name: High Sev Finding As Sample Data
+    ExpectedResult: false
+    Log:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {
+            "sample": true
+          },
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 8,
+        "id": "eeb88ab56556eb7771b266670dddee5a",
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }

--- a/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.py
@@ -1,7 +1,11 @@
-from panther_base_helpers import aws_guardduty_context
+from panther_base_helpers import aws_guardduty_context, deep_get
 
 
 def rule(event):
+    if deep_get(event, "service", "additionalInfo", "sample"):
+        # in case of sample data
+        # https://docs.aws.amazon.com/guardduty/latest/ug/sample_findings.html
+        return False
     return 0.1 <= float(event.get("severity", 0)) <= 3.9
 
 

--- a/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
@@ -66,3 +66,48 @@ Tests:
         "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
         "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
       }
+  -
+    Name: Low Sev Finding As Sample Data
+    ExpectedResult: false
+    Log:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {
+            "sample": true
+          },
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 1,
+        "id": "eeb88ab56556eb7771b266670dddee5a",
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }

--- a/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.py
@@ -1,7 +1,11 @@
-from panther_base_helpers import aws_guardduty_context
+from panther_base_helpers import aws_guardduty_context, deep_get
 
 
 def rule(event):
+    if deep_get(event, "service", "additionalInfo", "sample"):
+        # in case of sample data
+        # https://docs.aws.amazon.com/guardduty/latest/ug/sample_findings.html
+        return False
     return 4.0 <= float(event.get("severity", 0)) <= 6.9
 
 

--- a/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
@@ -66,3 +66,48 @@ Tests:
         "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
         "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
       }
+  -
+    Name: Medium Sev Finding As Sample Data
+    ExpectedResult: false
+    Log:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "id": "eeb88ab56556eb7771b266670dddee5a",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {
+            "sample": true
+          },
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 5,
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -15,3 +15,7 @@ def title(event):
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
         f"public by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
+
+
+def severity(event):
+    return "INFO" if deep_get(event, "parameters", "access_level") == "none" else "MEDIUM"

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -13,7 +13,8 @@ def title(event):
     return (
         f"GSuite calendar "
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
-        f"{public_or_private(event)} by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
+        f"{public_or_private(event)} by "
+        f"[{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
 
 

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -13,9 +13,13 @@ def title(event):
     return (
         f"GSuite calendar "
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
-        f"public by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
+        f"{public_or_private(event)} by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
 
 
 def severity(event):
-    return "INFO" if deep_get(event, "parameters", "access_level") == "none" else "MEDIUM"
+    return "LOW" if public_or_private(event) == "private" else "MEDIUM"
+
+
+def public_or_private(event):
+    return "private" if deep_get(event, "parameters", "access_level") == "none" else "public"

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
@@ -48,6 +48,34 @@ Tests:
         "type": "calendar_change"
       }
   -
+    Name: User Made Calendar Private
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "email": "user@example.io",
+          "profileId": "110111111111111111111"
+        },
+        "id": {
+          "applicationName": "calendar",
+          "customerId": "D12345",
+          "time": "2022-12-10 22:33:31.852000000",
+          "uniqueQualifier": "-2888888888888888888"
+        },
+        "ipAddress": "1.2.3.4",
+        "kind": "admin#reports#activity",
+        "name": "change_calendar_acls",
+        "ownerDomain": "example.io",
+        "parameters": {
+          "access_level": "none",
+          "api_kind": "web",
+          "calendar_id": "user@example.io",
+          "grantee_email": "__public_principal__@public.calendar.google.com",
+          "user_agent": "Mozilla/5.0"
+        },
+        "type": "calendar_change"
+      }
+  -
     Name: Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_WRITE_ACCESS
     ExpectedResult: false
     Log:

--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
@@ -6,7 +6,7 @@ ALLOWED_FORWARDING_DESTINATION_EMAILS = ["exception@example.com"]
 def rule(event):
     if event.get("operation", "") in ("Set-Mailbox", "New-InboxRule"):
         for param in event.get("parameters", []):
-            if param.get("Name", "") in ("ForwardingSmtpAddress", "ForwardTo"):
+            if param.get("Name", "") in ("ForwardingSmtpAddress", "ForwardTo", "ForwardingAddress"):
                 to_email = param.get("Value", "")
                 if to_email.lower().replace("smtp:", "") in ALLOWED_FORWARDING_DESTINATION_EMAILS:
                     return False

--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
@@ -167,6 +167,45 @@ Tests:
         usertype: 2
         workload: Exchange
       Name: Forwarding to Exception
+    - ExpectedResult: true
+      Log:
+        {
+          "AppAccessContext": {},
+          "ClientIP": "20.185.225.251:6688",
+          "CreationTime": "2023-10-24 13:06:33.000000000",
+          "ExternalAccess": false,
+          "Id": "78ab3f60-bd49-42e5-e69d-08dbd4920c3d",
+          "ObjectId": "28eb696a-03f7-47bd-a07a-b09d5f6e592e",
+          "Operation": "Set-Mailbox",
+          "OrganizationId": "18360841-3f87-44a6-8c9a-3ffc680611a0",
+          "OrganizationName": "fellowship.lotr.com",
+          "OriginatingServer": "AM6PR0402MB3448 (15.20.6933.008)",
+          "Parameters": [
+            {
+              "Name": "Identity",
+              "Value": "28eb696a-03f7-47bd-a07a-b09d5f6e592e"
+            },
+            {
+              "Name": "ForwardingAddress",
+              "Value": "sauron@mordor.dev"
+            },
+            {
+              "Name": "ForwardingSmtpAddress",
+              "Value": ""
+            },
+            {
+              "Name": "DeliverToMailboxAndForward",
+              "Value": "False"
+            }
+          ],
+          "RecordType": 1,
+          "ResultStatus": "True",
+          "UserId": "saurman@lotr.com",
+          "UserKey": "10032002CD6B7EFD",
+          "UserType": 2,
+          "Workload": "Exchange"
+        }
+      Name: Log with ForwardingAddress
 DedupPeriodMinutes: 60
 LogTypes:
     - Microsoft365.Audit.Exchange

--- a/rules/notion_rules/notion_account_changed_after_login.py
+++ b/rules/notion_rules/notion_account_changed_after_login.py
@@ -1,8 +1,8 @@
 import time
+
 from global_filter_notion import filter_include_event
 from panther_notion_helpers import notion_alert_context
 from panther_oss_helpers import get_string_set, put_string_set
-
 
 # Length of time in minutes. If a user logs in, then changes their email within this many
 # minutes, raise an alert.

--- a/rules/notion_rules/notion_login_from_new_location.py
+++ b/rules/notion_rules/notion_login_from_new_location.py
@@ -1,11 +1,11 @@
 import datetime
-import time
 import json
+import time
 
 from global_filter_notion import filter_include_event
+from panther_ipinfo_helpers import IPInfoLocation
 from panther_notion_helpers import notion_alert_context
 from panther_oss_helpers import get_dictionary, put_dictionary
-from panther_ipinfo_helpers import IPInfoLocation
 
 # How long (in seconds) to keep previous login locations in cached memory
 DEFAULT_CACHE_PERIOD = 2419200

--- a/rules/notion_rules/notion_page_accessible_to_guests.py
+++ b/rules/notion_rules/notion_page_accessible_to_guests.py
@@ -1,6 +1,6 @@
 from global_filter_notion import filter_include_event
-from panther_notion_helpers import notion_alert_context
 from panther_base_helpers import deep_get
+from panther_notion_helpers import notion_alert_context
 
 # These event types correspond to users adding or editing the default role on a public page
 event_types = ("page.permissions.guest_role_added", "page.permissions.guest_role_updated")

--- a/rules/notion_rules/notion_page_view_impossible_travel.yml
+++ b/rules/notion_rules/notion_page_view_impossible_travel.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: notion_page_view_impossible_travel.py
 RuleID: "Notion.PageViews.ImpossibleTravel"
-DisplayName: "Notion Page View Impossible Travel"
-Enabled: true
+DisplayName: "Notion Page View Impossible Travel DEPRECATED"
+Enabled: false
 LogTypes:
     - Notion.AuditLogs
 Tags:

--- a/rules/notion_rules/notion_workspace_settings_enforce_saml_sso_config_updated.py
+++ b/rules/notion_rules/notion_workspace_settings_enforce_saml_sso_config_updated.py
@@ -18,6 +18,7 @@ def title(event):
     state = deep_get(
         event,
         "event",
+        "workspace.settings.enforce_saml_sso_config_updated",
         "state",
         default="<NO_STATE_FOUND>",
     )

--- a/rules/okta_rules/okta_geo_improbable_access.py
+++ b/rules/okta_rules/okta_geo_improbable_access.py
@@ -3,11 +3,7 @@ from json import dumps, loads
 from math import asin, cos, radians, sin, sqrt
 
 from panther_base_helpers import deep_get, okta_alert_context
-from panther_detection_helpers.caching import (
-    get_string_set,
-    put_string_set,
-    set_key_expiration,
-)
+from panther_detection_helpers.caching import get_string_set, put_string_set
 
 PANTHER_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 EVENT_CITY_TRACKING = {}
@@ -98,9 +94,8 @@ def store_login_info(key, event):
                 }
             )
         ],
+        epoch_seconds=event.event_time_epoch() + timedelta(days=7).total_seconds(),
     )
-    # Expire the entry after a week so the table doesn't fill up with past users
-    set_key_expiration(key, int((datetime.now() + timedelta(days=7)).timestamp()))
 
 
 def title(event):

--- a/rules/okta_rules/okta_geo_improbable_access.yml
+++ b/rules/okta_rules/okta_geo_improbable_access.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: okta_geo_improbable_access.py
 RuleID: "Okta.GeographicallyImprobableAccess"
-DisplayName: "Geographically Improbable Okta Login"
-Enabled: true
+DisplayName: "Geographically Improbable Okta Login - DEPRECATED"
+Enabled: false
 LogTypes:
   - Okta.SystemLog
 Tags:

--- a/rules/onelogin_rules/onelogin_active_login_activity.py
+++ b/rules/onelogin_rules/onelogin_active_login_activity.py
@@ -1,15 +1,14 @@
-import time
+from datetime import timedelta
 
 from panther_base_helpers import is_ip_in_network
 from panther_detection_helpers.caching import (
     add_to_string_set,
     get_string_set,
     put_string_set,
-    set_key_expiration,
 )
 
 THRESH = 2
-THRESH_TTL = 43200  # 1/2 day
+THRESH_TTL = timedelta(hours=12).total_seconds()
 
 # Safelist for IP Subnets to ignore in this ruleset
 # Each entry in the list should be in CIDR notation
@@ -41,13 +40,13 @@ def rule(event):
     user_id = str(event.get("user_id"))
     if not user_ids:
         # store this as the first user login from this ip address
-        put_string_set(event_key, [user_id])
-        set_key_expiration(event_key, int(time.time()) + THRESH_TTL)
+        put_string_set(event_key, [user_id], epoch_seconds=event.event_time_epoch() + THRESH_TTL)
         return False
     # add a new username if this is a unique user from this ip address
     if user_id not in user_ids:
-        user_ids = add_to_string_set(event_key, user_id)
-        set_key_expiration(event_key, int(time.time()) + THRESH_TTL)
+        user_ids = add_to_string_set(
+            event_key, user_id, epoch_seconds=event.event_time_epoch() + THRESH_TTL
+        )
     return len(user_ids) > THRESH
 
 

--- a/rules/onelogin_rules/onelogin_high_risk_login.py
+++ b/rules/onelogin_rules/onelogin_high_risk_login.py
@@ -1,13 +1,12 @@
-import time
+from datetime import timedelta
 
 from panther_detection_helpers.caching import (
     get_counter,
     increment_counter,
     reset_counter,
-    set_key_expiration,
 )
 
-THRESH_TTL = 600
+THRESH_TTL = timedelta(minutes=10).total_seconds()
 
 
 def rule(event):
@@ -21,8 +20,7 @@ def rule(event):
         # a failed authentication attempt with high risk score
         if str(event.get("event_type_id")) == "6":
             # update a counter for this user's failed login attempts with a high risk score
-            increment_counter(event_key)
-            set_key_expiration(event_key, int(time.time()) + THRESH_TTL)
+            increment_counter(event_key, event.event_time_epoch() + THRESH_TTL)
 
     # Trigger alert if this user recently
     # failed a high risk login

--- a/rules/panther_audit_rules/panther_user_modified.py
+++ b/rules/panther_audit_rules/panther_user_modified.py
@@ -15,7 +15,9 @@ def rule(event):
 def title(event):
     change_target = deep_get(event, "actionParams", "dynamic", "input", "email")
     if change_target is None:
-        change_target = deep_get(event, "actionParams", "input", "email", default="<UNKNOWN_USER>")
+        change_target = deep_get(event, "actionParams", "input", "email")
+    if change_target is None:
+        change_target = deep_get(event, "actionParams", "email", default="<UNKNOWN_USER>")
     return f"The user account " f"{change_target} " f"was modified by {event.udm('actor_user')}"
 
 

--- a/rules/panther_audit_rules/panther_user_modified.yml
+++ b/rules/panther_audit_rules/panther_user_modified.yml
@@ -205,3 +205,26 @@ Tests:
         "sourceIP": "12.12.12.12",
         "timestamp": "2023-06-23 17:49:37.553847671"
       }
+  - Name: User modified by System account
+    ExpectedResult: true
+    Log:
+      {
+      "actionDescription": "User updated automatically by SAML.",
+      "actionName": "UPDATE_USER",
+      "actionParams": {
+          "email": "john.doe@usgs.gov",
+          "familyName": "Doe",
+          "givenName": "John",
+          "role": "AnalystReadOnly"
+      },
+      "actionResult": "SUCCEEDED",
+      "actor": {
+          "id": "00000000-0000-4000-8000-000000000000",
+          "name": "System",
+          "type": "USER"
+      },
+      "p_log_type": "Panther.Audit",
+      "pantherVersion": "1.86.15",
+      "sourceIP": "",
+      "timestamp": "2023-10-25 05:30:15.618835297"
+    }

--- a/rules/slack_rules/slack_application_dos.py
+++ b/rules/slack_rules/slack_application_dos.py
@@ -1,12 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from json import dumps
 
 from panther_base_helpers import deep_get, slack_alert_context
-from panther_detection_helpers.caching import (
-    get_string_set,
-    put_string_set,
-    set_key_expiration,
-)
+from panther_detection_helpers.caching import get_string_set, put_string_set
 
 DENIAL_OF_SERVICE_ACTIONS = [
     "bulk_session_reset_by_admin",
@@ -55,6 +51,5 @@ def store_reset_info(key, event):
                 }
             )
         ],
+        epoch_seconds=event.event_time_epoch() + timedelta(days=1).total_seconds(),
     )
-    # Expire the entry after 24 hours
-    set_key_expiration(key, int((datetime.now() + timedelta(days=1)).timestamp()))

--- a/rules/slack_rules/slack_application_dos.yml
+++ b/rules/slack_rules/slack_application_dos.yml
@@ -25,8 +25,6 @@ Tests:
         returnValue: ""
       - objectName: put_string_set
         returnValue: ""
-      - objectName: set_key_expiration
-        returnValue: ""
     Log:
       {
         "action": "user_session_reset_by_admin",
@@ -57,8 +55,6 @@ Tests:
       - objectName: get_string_set
         returnValue: "{\"time\":\"2021-06-08 22:24:43\"}"
       - objectName: put_string_set
-        returnValue: ""
-      - objectName: set_key_expiration
         returnValue: ""
     Log:
       {

--- a/rules/slack_rules/slack_privilege_changed_to_user.yml
+++ b/rules/slack_rules/slack_privilege_changed_to_user.yml
@@ -8,7 +8,7 @@ LogTypes:
 Tags:
   - Slack
 Severity: Medium
-Description: Detects when a Slack account is to User from an elevated role.
+Description: Detects when a Slack account is changed to User from an elevated role.
 Reference: https://api.slack.com/admins/audit-logs
 DedupPeriodMinutes: 60
 Threshold:  1

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -30,12 +30,12 @@ def rule(event):
     global EVENT_CITY_TRACKING
     global CACHE_KEY
     global IS_VPN
-    global IS_APPLE_PRIVATE_RELAY
+    global IS_PRIVATE_RELAY
 
     EVENT_CITY_TRACKING = {}
     CACHE_KEY = None
     IS_VPN = False
-    IS_APPLE_PRIVATE_RELAY = False
+    IS_PRIVATE_RELAY = False
 
     # Only evaluate successful logins
     if event.udm("event_type") != event_type.SUCCESSFUL_LOGIN:
@@ -65,14 +65,14 @@ def rule(event):
     if None in new_login_stats.values():
         return False
 
-    ## Check for VPN or Apple Private Relay
+    ## Check for VPN or Private Relay
     ipinfo_privacy = deep_get(src_ip_enrichments, "ipinfo_privacy")
     if ipinfo_privacy is not None:
-        ###  Do VPN/Apple private relay
-        IS_APPLE_PRIVATE_RELAY = all(
+        ###  Do VPN/private relay
+        IS_PRIVATE_RELAY = all(
             [
                 deep_get(ipinfo_privacy, "relay", default=False),
-                deep_get(ipinfo_privacy, "service", default="") == "Apple Private Relay",
+                deep_get(ipinfo_privacy, "service", default="") != "",
             ]
         )
         # We've found that some places, like WeWork locations,
@@ -87,11 +87,11 @@ def rule(event):
                 deep_get(ipinfo_privacy, "service", default="") != "",
             ]
         )
-    if IS_VPN or IS_APPLE_PRIVATE_RELAY:
+    if IS_VPN or IS_PRIVATE_RELAY:
         new_login_stats.update(
             {
                 "is_vpn": f"{IS_VPN}",
-                "is_apple_priv_relay": f"{IS_APPLE_PRIVATE_RELAY}",
+                "is_apple_priv_relay": f"{IS_PRIVATE_RELAY}",
                 "service_name": f"{deep_get(ipinfo_privacy, 'service', default='<NO_SERVICE>')}",
                 "NOTE": "APPLE PRIVATE RELAY AND VPN LOGINS ARE NOT CACHED FOR COMPARISON",
             }
@@ -106,12 +106,13 @@ def rule(event):
     last_login = get_string_set(CACHE_KEY)
     # If we haven't seen this user login in the past 1 day,
     # store this login for future use and don't alert
-    if not last_login and not IS_APPLE_PRIVATE_RELAY and not IS_VPN:
-        put_string_set(
-            key=CACHE_KEY,
-            val=[dumps(new_login_stats)],
-            epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
-        )
+    if not last_login:
+        if not (IS_PRIVATE_RELAY or IS_VPN):
+            put_string_set(
+                key=CACHE_KEY,
+                val=[dumps(new_login_stats)],
+                epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+            )
         return False
     # Load the last login from the cache into an object we can compare
     # str check is in place for unit test mocking
@@ -133,11 +134,13 @@ def rule(event):
     speed = distance / time_delta
 
     # Calculation is complete, write the current login to the cache
-    put_string_set(
-        key=CACHE_KEY,
-        val=[dumps(new_login_stats)],
-        epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
-    )
+    # Only if non-VPN non-relay!
+    if not IS_PRIVATE_RELAY and not IS_VPN:
+        put_string_set(
+            key=CACHE_KEY,
+            val=[dumps(new_login_stats)],
+            epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+        )
 
     EVENT_CITY_TRACKING["previous"] = last_login_stats
     EVENT_CITY_TRACKING["current"] = new_login_stats
@@ -176,7 +179,7 @@ def alert_context(event):
 
 
 def severity(_):
-    if IS_VPN or IS_APPLE_PRIVATE_RELAY:
+    if IS_VPN or IS_PRIVATE_RELAY:
         return "INFO"
     # time = distance/speed
     distance = deep_get(EVENT_CITY_TRACKING, "distance", default=None)

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -787,4 +787,89 @@ Tests:
         "p_log_type": "Notion.AuditLogs",
         "p_source_label": "Notion-Panther-Labs"
       }
-
+  - Name: First hit from VPN should not fail
+    ExpectedResult: false
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: ""
+    Log:
+      {
+        "actor": {
+          "alternateId": "homer.simpson@company.com",
+          "displayName": "Homer Simpson",
+          "id": "00uwuwuwuwuwuwuwuwuw",
+          "type": "User"
+        },
+        "authenticationContext": {
+          "authenticationStep": 0,
+          "externalSessionId": "idx1234"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "12.12.12.12",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+          },
+          "zone": "null"
+        },
+        "debugContext": {
+          "debugData": {
+          }
+        },
+        "device": {
+        },
+        "displayMessage": "User login to Okta",
+        "eventType": "user.session.start",
+        "legacyEventType": "core.user_auth.login_success",
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "p_event_time": "2023-05-26 20:18:51",
+        "p_enrichment": {
+          "ipinfo_location": {
+            "client.ipAddress": {
+              "city": "Los Angeles",
+              "country": "US",
+              "lat": "34.05223",
+              "lng": "-118.24368",
+              "p_match": "12.12.12.12",
+              "postal_code": "90009",
+              "region": "California",
+              "region_code": "CA",
+              "timezone": "America/Los_Angeles"
+            }
+          },
+          "ipinfo_privacy": {
+            "client.ipAddress": {
+              "hosting": true,
+              "p_match": "12.12.12.12",
+              "proxy": false,
+              "relay": true,
+              "service": "Apple Private Relay",
+              "tor": false,
+              "vpn": false
+            }
+          }
+        },
+        "p_log_type": "Okta.SystemLog",
+        "p_source_label": "Okta Logs",
+        "p_parse_time": "2023-05-26 20:22:51.888",
+        "published": "2023-05-26 20:18:51.888",
+        "request": {
+          "ipChain": [
+          ]
+        },
+        "securityContext": {
+        },
+        "severity": "INFO",
+        "target": [
+        ],
+        "transaction": {
+        },
+        "uuid": "79999999-ffff-eeee-bbbb-222222222222",
+        "version": "0"
+      }


### PR DESCRIPTION
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/calendar#change_calendar_acls

None means nobody can see your calendar. This should just be info level.

### Background

When changing a calendar from freebusy to say 'none' it should only be INFO severity.

### Changes
Change severity based on access change

### Testing

Is there a way to test for severity?
